### PR TITLE
feat: Use cross for broader glibc compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           # Linux
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            use-cross: false
+            use-cross: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             use-cross: true


### PR DESCRIPTION
## Why

I could not get the current version to run on my self-hosted Github Actions runner, which is based on Ubuntu 22 and uses an older version of glibc. This is too new an operating system not to support! It happens because builds are taking place on Ubuntu 24 without backward compatibility in mind. Closes #28 

## What

Use the cross build tool on the `x86_64-unknown-linux-gnu` target, which will enable [glibc 2.17 compatibility](https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools).